### PR TITLE
Update description

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Autocasting
 author=Vivascape, JC A
 support=
-description=Notifies client when the player's magic level falls below the level required for the autocast spell.
+description=Tracks your autocast spell and alerts you when it can't be used.
 tags=notifier,notifications,mage,magic,reduced,reduction,level,drain,autocasting,autocast,cast,casts,utilities,brew,runes,tracker,alert
 plugins=com.autocasting.AutocastingPlugin

--- a/src/main/java/com/autocasting/AutocastingPlugin.java
+++ b/src/main/java/com/autocasting/AutocastingPlugin.java
@@ -19,7 +19,7 @@ TODO: Only show overlay when player is equipping a staff or other autocastable w
 
 @PluginDescriptor(
 	name = "Autocasting",
-	description = "Notifies client when magic level falls below required level for spell.",
+	description = "Tracks your autocast spell and alerts you when it can't be used.",
 	tags = {"notifier", "notifications", "mage", "magic", "reduced", "reduction", "level", "drain", "autocasting", "autocast", "cast", "casts", "utilities", "brew", "runes", "tracker", "alert"}
 )
 public class AutocastingPlugin extends Plugin


### PR DESCRIPTION
This is the phrase that shows up on the plugin hub search, right now the description feels kind of out of place
![image](https://github.com/jcarbelbide/autocasting/assets/14102263/c9cadf50-e254-4696-99af-950ce9067c96)
