### PR TITLE
Fix: Treat bladed staves as magic weapons.

### DIFF
--- a/src/main/java/com/autocasting/AutocastingState.java
+++ b/src/main/java/com/autocasting/AutocastingState.java
@@ -140,7 +140,8 @@ public class AutocastingState
 		currentWeaponType = newWeaponType;
 
 		isEquippedWeaponMagic = newWeaponType == WeaponType.TYPE_18 ||
-			newWeaponType == WeaponType.TYPE_21;
+								newWeaponType == WeaponType.TYPE_21 ||
+								newWeaponType == WeaponType.TYPE_22;
 
 		// The below types do have a casting option, but do not autocast spells, so leave them out.
 		// TYPE_6: These are salamanders. They do not autocast, but give magic xp, so technically have a "casting" option.


### PR DESCRIPTION
This change updates the logic so that bladed staves are treated as magic weapons. I added `WeaponType.TYPE_22` to the list of recognized magic weapon types.

I tested this with the Blue Moon Spear (the only bladed staff I have). It seems to work fine, but testing with other bladed staves would be great to make sure everything’s good.