### PR TITLE
Fix issues introduced with autocasting game update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,61 @@
 plugins {
-	id 'java'
+    id 'java'
 }
 
 repositories {
-	mavenLocal()
-	maven {
-		url = 'https://repo.runelite.net'
-	}
-	mavenCentral()
+    mavenLocal()
+    maven {
+        url = 'https://repo.runelite.net'
+        content {
+            includeGroupByRegex("net\\.runelite.*")
+        }
+    }
+    mavenCentral()
 }
 
 def runeLiteVersion = 'latest.release'
 
 dependencies {
-	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+    compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-	testImplementation 'junit:junit:4.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
-	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+    testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'com.autocasting'
 version = '1.0'
 
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
-	options.release.set(11)
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release.set(11)
+}
+
+tasks.register('shadowJar', Jar) {
+    dependsOn configurations.testRuntimeClasspath
+    manifest {
+        attributes('Main-Class': 'com.autocasting.AutocastingPluginTest', 'Multi-Release': true)
+    }
+
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from sourceSets.main.output
+    from sourceSets.test.output
+    from {
+        configurations.testRuntimeClasspath.collect { file ->
+            file.isDirectory() ? file : zipTree(file)
+        }
+    }
+
+    exclude 'META-INF/INDEX.LIST'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
+    exclude '**/module-info.class'
+
+    group = BasePlugin.BUILD_GROUP
+    archiveClassifier.set('shadow')
+    archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
 }

--- a/src/main/java/com/autocasting/AutocastingState.java
+++ b/src/main/java/com/autocasting/AutocastingState.java
@@ -72,8 +72,7 @@ public class AutocastingState
 		{
 			return;
 		}
-		// Some input (weapon change, attack style change, or autocast change) happened, so magic level must be fine now
-		setMagicLevelTooLowForSpell(false);
+
 		// If the new spell is not null, and there is currently no autocast spell selected, update it
 		if (currentAutocastSpell == null || newAutocastSpell.getVarbitValue() != currentAutocastSpell.getVarbitValue())
 		{
@@ -116,6 +115,12 @@ public class AutocastingState
 	{
 		if (currentAutocastSpell == null || currentAutocastSpell == Spell.NO_SPELL)
 		{
+			castsRemaining = 0;
+			return;
+		}
+		if (availableRunes == null) {
+			// Race condition upon startup, autocast varbit may be set before inventory is loaded.
+			// availableRunes will not be set, but will get set soon after; update casts remaining then
 			castsRemaining = 0;
 			return;
 		}


### PR DESCRIPTION
A polish to the game's autocasting system released today, 2025-04-09. Full details are available [here](https://secure.runescape.com/m=news/a=13/farming--autocast-qol-improvements?oldschool=1), but I've enumerated the changes relevant to this plugin:

- Reduced magic level / running out of runes, and performing a combat action afterwards (typically a melee) no longer unsets the current autocast varbit.
- An autocast can be set without having the proper runes / level requirements.
- Varbit remains even when changing to a different weapon which can autocast, but not on the current spellbook.
- Varbit remains even between sessions, meaning the plugin should read all this on login (first login on the client especially) and correctly interpret the state. Game data is loaded in stages, e.g. the autocasting varbit is set first, before inventory and equipment is known. The plugin currently will hit a null pointer and crash.

Other than the login issue, which is fixed by adding another null check, most of these are fixed by removing assumptions. For example, if the autocasting varbit is set and we read an equipment change event, we were assuming then you had the level and runes to cast and set flags accordingly. We can no longer do this; state updates need to happen only by the relevant events.

All that to say, these were resolvable with two fixes.

I also updated the build.gradle because mine was out of date and not reading imports correctly. New version is directly from the plugin hub's latest template.