### PR TITLE
Add aether rune, use new runelite itemId repository

### DIFF
--- a/src/main/java/com/autocasting/datatypes/RuneItem.java
+++ b/src/main/java/com/autocasting/datatypes/RuneItem.java
@@ -4,7 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import net.runelite.api.ItemID;
+//import net.runelite.api.ItemID;
+import net.runelite.api.gameval.ItemID;
 
 import java.util.Map;
 
@@ -16,84 +17,85 @@ import java.util.Map;
 @Getter
 public enum RuneItem
 {
-	AIR_RUNE(ItemID.AIR_RUNE, new RuneType[]{RuneType.AIR}),
-	AIR_RUNE_6422(ItemID.AIR_RUNE_6422, new RuneType[]{RuneType.AIR}),
-	AIR_RUNE_7558(ItemID.AIR_RUNE_7558, new RuneType[]{RuneType.AIR}),
-	AIR_RUNE_9693(ItemID.AIR_RUNE_9693, new RuneType[]{RuneType.AIR}),
-	AIR_RUNE_11688(ItemID.AIR_RUNE_11688, new RuneType[]{RuneType.AIR}),
-	AIR_RUNE_NZ(ItemID.AIR_RUNE_NZ, new RuneType[]{RuneType.AIR}),
+	AIR_RUNE(ItemID.AIRRUNE, new RuneType[]{RuneType.AIR}),
+	ROGUETRADER_AIRRUNE(ItemID.ROGUETRADER_AIRRUNE, new RuneType[]{RuneType.AIR}),
+	_100GUIDE_AIRRUNE_DUM(ItemID._100GUIDE_AIRRUNE_DUM, new RuneType[]{RuneType.AIR}),
+	SLUG2_RUNE_AIR(ItemID.SLUG2_RUNE_AIR, new RuneType[]{RuneType.AIR}),
+	FAKE_AIRRUNE(ItemID.FAKE_AIRRUNE, new RuneType[]{RuneType.AIR}),
+	NZONE_AIRRUNE(ItemID.NZONE_AIRRUNE, new RuneType[]{RuneType.AIR}),
 
-	WATER_RUNE(ItemID.WATER_RUNE, new RuneType[]{RuneType.WATER}),
-	WATER_RUNE_6424(ItemID.WATER_RUNE_6424, new RuneType[]{RuneType.WATER}),
-	WATER_RUNE_7556(ItemID.WATER_RUNE_7556, new RuneType[]{RuneType.WATER}),
-	WATER_RUNE_9691(ItemID.WATER_RUNE_9691, new RuneType[]{RuneType.WATER}),
-	WATER_RUNE_11687(ItemID.WATER_RUNE_11687, new RuneType[]{RuneType.WATER}),
-	WATER_RUNE_NZ(ItemID.WATER_RUNE_NZ, new RuneType[]{RuneType.WATER}),
+	WATER_RUNE(ItemID.WATERRUNE, new RuneType[]{RuneType.WATER}),
+	ROGUETRADER_WATERRUNE(ItemID.ROGUETRADER_WATERRUNE, new RuneType[]{RuneType.WATER}),
+	_100GUIDE_WATERRUNE_DUM(ItemID._100GUIDE_WATERRUNE_DUM, new RuneType[]{RuneType.WATER}),
+	SLUG2_RUNE_WATER(ItemID.SLUG2_RUNE_WATER, new RuneType[]{RuneType.WATER}),
+	FAKE_WATERRUNE(ItemID.FAKE_WATERRUNE, new RuneType[]{RuneType.WATER}),
+	NZONE_WATERRUNE(ItemID.NZONE_WATERRUNE, new RuneType[]{RuneType.WATER}),
 
-	EARTH_RUNE(ItemID.EARTH_RUNE, new RuneType[]{RuneType.EARTH}),
-	EARTH_RUNE_6426(ItemID.EARTH_RUNE_6426, new RuneType[]{RuneType.EARTH}),
-	EARTH_RUNE_9695(ItemID.EARTH_RUNE_9695, new RuneType[]{RuneType.EARTH}),
-	EARTH_RUNE_11689(ItemID.EARTH_RUNE_11689, new RuneType[]{RuneType.EARTH}),
-	EARTH_RUNE_NZ(ItemID.EARTH_RUNE_NZ, new RuneType[]{RuneType.EARTH}),
+	EARTH_RUNE(ItemID.EARTHRUNE, new RuneType[]{RuneType.EARTH}),
+	ROGUETRADER_EARTHRUNE(ItemID.ROGUETRADER_EARTHRUNE, new RuneType[]{RuneType.EARTH}),
+	SLUG2_RUNE_EARTH(ItemID.SLUG2_RUNE_EARTH, new RuneType[]{RuneType.EARTH}),
+	FAKE_EARTHRUNE(ItemID.FAKE_EARTHRUNE, new RuneType[]{RuneType.EARTH}),
+	NZONE_EARTHRUNE(ItemID.NZONE_EARTHRUNE, new RuneType[]{RuneType.EARTH}),
 
-	FIRE_RUNE(ItemID.FIRE_RUNE, new RuneType[]{RuneType.FIRE}),
-	FIRE_RUNE_6428(ItemID.FIRE_RUNE_6428, new RuneType[]{RuneType.FIRE}),
-	FIRE_RUNE_7554(ItemID.FIRE_RUNE_7554, new RuneType[]{RuneType.FIRE}),
-	FIRE_RUNE_9699(ItemID.FIRE_RUNE_9699, new RuneType[]{RuneType.FIRE}),
-	FIRE_RUNE_11686(ItemID.FIRE_RUNE_11686, new RuneType[]{RuneType.FIRE}),
-	FIRE_RUNE_NZ(ItemID.FIRE_RUNE_NZ, new RuneType[]{RuneType.FIRE}),
-	SUNFIRE_RUNE(ItemID.SUNFIRE_RUNE, new RuneType[]{RuneType.FIRE}),
+	FIRE_RUNE(ItemID.FIRERUNE, new RuneType[]{RuneType.FIRE}),
+	ROGUETRADER_FIRERUNE(ItemID.ROGUETRADER_FIRERUNE, new RuneType[]{RuneType.FIRE}),
+	_100GUIDE_FIRERUNE_DUM(ItemID._100GUIDE_FIRERUNE_DUM, new RuneType[]{RuneType.FIRE}),
+	SLUG2_RUNE_FIRE(ItemID.SLUG2_RUNE_FIRE, new RuneType[]{RuneType.FIRE}),
+	FAKE_FIRERUNE(ItemID.FAKE_FIRERUNE, new RuneType[]{RuneType.FIRE}),
+	NZONE_FIRERUNE(ItemID.NZONE_FIRERUNE, new RuneType[]{RuneType.FIRE}),
+	SUNFIRE_RUNE(ItemID.SUNFIRERUNE, new RuneType[]{RuneType.FIRE}),
 
-	MIND_RUNE(ItemID.MIND_RUNE, new RuneType[]{RuneType.MIND}),
-	MIND_RUNE_6436(ItemID.MIND_RUNE_6436, new RuneType[]{RuneType.MIND}),
-	MIND_RUNE_9697(ItemID.MIND_RUNE_9697, new RuneType[]{RuneType.MIND}),
-	MIND_RUNE_11690(ItemID.MIND_RUNE_11690, new RuneType[]{RuneType.MIND}),
+	MIND_RUNE(ItemID.MINDRUNE, new RuneType[]{RuneType.MIND}),
+	ROGUETRADER_MINDRUNE(ItemID.ROGUETRADER_MINDRUNE, new RuneType[]{RuneType.MIND}),
+	SLUG2_RUNE_MIND(ItemID.SLUG2_RUNE_MIND, new RuneType[]{RuneType.MIND}),
+	FAKE_MINDRUNE(ItemID.FAKE_MINDRUNE, new RuneType[]{RuneType.MIND}),
 
-	BODY_RUNE(ItemID.BODY_RUNE, new RuneType[]{RuneType.BODY}),
-	BODY_RUNE_6438(ItemID.BODY_RUNE_6438, new RuneType[]{RuneType.BODY}),
-	BODY_RUNE_11691(ItemID.BODY_RUNE_11691, new RuneType[]{RuneType.BODY}),
+	BODY_RUNE(ItemID.BODYRUNE, new RuneType[]{RuneType.BODY}),
+	ROGUETRADER_BODYRUNE(ItemID.ROGUETRADER_BODYRUNE, new RuneType[]{RuneType.BODY}),
+	FAKE_BODYRUNE(ItemID.FAKE_BODYRUNE, new RuneType[]{RuneType.BODY}),
 
-	COSMIC_RUNE(ItemID.COSMIC_RUNE, new RuneType[]{RuneType.COSMIC}),
-	COSMIC_RUNE_11696(ItemID.COSMIC_RUNE_11696, new RuneType[]{RuneType.COSMIC}),
+	COSMIC_RUNE(ItemID.COSMICRUNE, new RuneType[]{RuneType.COSMIC}),
+	FAKE_COSMICRUNE(ItemID.FAKE_COSMICRUNE, new RuneType[]{RuneType.COSMIC}),
 
-	CHAOS_RUNE(ItemID.CHAOS_RUNE, new RuneType[]{RuneType.CHAOS}),
-	CHAOS_RUNE_6430(ItemID.CHAOS_RUNE_6430, new RuneType[]{RuneType.CHAOS}),
-	CHAOS_RUNE_7560(ItemID.CHAOS_RUNE_7560, new RuneType[]{RuneType.CHAOS}),
-	CHAOS_RUNE_11694(ItemID.CHAOS_RUNE_11694, new RuneType[]{RuneType.CHAOS}),
-	CHAOS_RUNE_NZ(ItemID.CHAOS_RUNE_NZ, new RuneType[]{RuneType.CHAOS}),
+	CHAOS_RUNE(ItemID.CHAOSRUNE, new RuneType[]{RuneType.CHAOS}),
+	ROGUETRADER_CHAOSRUNE(ItemID.ROGUETRADER_CHAOSRUNE, new RuneType[]{RuneType.CHAOS}),
+	_100GUIDE_CHAOSRUNE_DUM(ItemID._100GUIDE_CHAOSRUNE_DUM, new RuneType[]{RuneType.CHAOS}),
+	FAKE_CHAOSRUNE(ItemID.FAKE_CHAOSRUNE, new RuneType[]{RuneType.CHAOS}),
+	NZONE_CHAOSRUNE(ItemID.NZONE_CHAOSRUNE, new RuneType[]{RuneType.CHAOS}),
 
-	NATURE_RUNE(ItemID.NATURE_RUNE, new RuneType[]{RuneType.NATURE}),
-	NATURE_RUNE_11693(ItemID.NATURE_RUNE_11693, new RuneType[]{RuneType.NATURE}),
+	NATURE_RUNE(ItemID.NATURERUNE, new RuneType[]{RuneType.NATURE}),
+	FAKE_NATURERUNE(ItemID.FAKE_NATURERUNE, new RuneType[]{RuneType.NATURE}),
 
-	LAW_RUNE(ItemID.LAW_RUNE, new RuneType[]{RuneType.LAW}),
-	LAW_RUNE_6434(ItemID.LAW_RUNE_6434, new RuneType[]{RuneType.LAW}),
-	LAW_RUNE_11695(ItemID.LAW_RUNE_11695, new RuneType[]{RuneType.LAW}),
+	LAW_RUNE(ItemID.LAWRUNE, new RuneType[]{RuneType.LAW}),
+	ROGUETRADER_LAWRUNE(ItemID.ROGUETRADER_LAWRUNE, new RuneType[]{RuneType.LAW}),
+	FAKE_LAWRUNE(ItemID.FAKE_LAWRUNE, new RuneType[]{RuneType.LAW}),
 
-	DEATH_RUNE(ItemID.DEATH_RUNE, new RuneType[]{RuneType.DEATH}),
-	DEATH_RUNE_6432(ItemID.DEATH_RUNE_6432, new RuneType[]{RuneType.DEATH}),
-	DEATH_RUNE_11692(ItemID.DEATH_RUNE_11692, new RuneType[]{RuneType.DEATH}),
-	DEATH_RUNE_NZ(ItemID.DEATH_RUNE_NZ, new RuneType[]{RuneType.DEATH}),
+	DEATH_RUNE(ItemID.DEATHRUNE, new RuneType[]{RuneType.DEATH}),
+	ROGUETRADER_DEATHRUNE(ItemID.ROGUETRADER_DEATHRUNE, new RuneType[]{RuneType.DEATH}),
+	FAKE_DEATHRUNE(ItemID.FAKE_DEATHRUNE, new RuneType[]{RuneType.DEATH}),
+	NZONE_DEATHRUNE(ItemID.NZONE_DEATHRUNE, new RuneType[]{RuneType.DEATH}),
 
-	ASTRAL_RUNE(ItemID.ASTRAL_RUNE, new RuneType[]{RuneType.ASTRAL}),
-	ASTRAL_RUNE_11699(ItemID.ASTRAL_RUNE_11699, new RuneType[]{RuneType.ASTRAL}),
+	ASTRAL_RUNE(ItemID.ASTRALRUNE, new RuneType[]{RuneType.ASTRAL}),
+	FAKE_ASTRALRUNE(ItemID.FAKE_ASTRALRUNE, new RuneType[]{RuneType.ASTRAL}),
 
-	BLOOD_RUNE(ItemID.BLOOD_RUNE, new RuneType[]{RuneType.BLOOD}),
-	BLOOD_RUNE_11697(ItemID.BLOOD_RUNE_11697, new RuneType[]{RuneType.BLOOD}),
-	BLOOD_RUNE_NZ(ItemID.BLOOD_RUNE_NZ, new RuneType[]{RuneType.BLOOD}),
+	BLOOD_RUNE(ItemID.BLOODRUNE, new RuneType[]{RuneType.BLOOD}),
+	FAKE_BLOODRUNE(ItemID.FAKE_BLOODRUNE, new RuneType[]{RuneType.BLOOD}),
+	NZONE_BLOODRUNE(ItemID.NZONE_BLOODRUNE, new RuneType[]{RuneType.BLOOD}),
 
-	SOUL_RUNE(ItemID.SOUL_RUNE, new RuneType[]{RuneType.SOUL}),
-	SOUL_RUNE_11698(ItemID.SOUL_RUNE_11698, new RuneType[]{RuneType.SOUL}),
+	SOUL_RUNE(ItemID.SOULRUNE, new RuneType[]{RuneType.SOUL}),
+	FAKE_SOULRUNE(ItemID.FAKE_SOULRUNE, new RuneType[]{RuneType.SOUL}),
 
-	WRATH_RUNE(ItemID.WRATH_RUNE, new RuneType[]{RuneType.WRATH}),
-	WRATH_RUNE_22208(ItemID.WRATH_RUNE_22208, new RuneType[]{RuneType.WRATH}),
+	WRATH_RUNE(ItemID.WRATHRUNE, new RuneType[]{RuneType.WRATH}),
+	FAKE_WRATHRUNE(ItemID.FAKE_WRATHRUNE, new RuneType[]{RuneType.WRATH}),
 
 	// Combo runes
-	MIST_RUNE(ItemID.MIST_RUNE, new RuneType[]{RuneType.AIR, RuneType.WATER}),
-	DUST_RUNE(ItemID.DUST_RUNE, new RuneType[]{RuneType.AIR, RuneType.EARTH}),
-	MUD_RUNE(ItemID.MUD_RUNE, new RuneType[]{RuneType.WATER, RuneType.EARTH}),
-	SMOKE_RUNE(ItemID.SMOKE_RUNE, new RuneType[]{RuneType.AIR, RuneType.FIRE}),
-	STEAM_RUNE(ItemID.STEAM_RUNE, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
-	LAVA_RUNE(ItemID.LAVA_RUNE, new RuneType[]{RuneType.EARTH, RuneType.FIRE});
+	MIST_RUNE(ItemID.MISTRUNE, new RuneType[]{RuneType.AIR, RuneType.WATER}),
+	DUST_RUNE(ItemID.DUSTRUNE, new RuneType[]{RuneType.AIR, RuneType.EARTH}),
+	MUD_RUNE(ItemID.MUDRUNE, new RuneType[]{RuneType.WATER, RuneType.EARTH}),
+	SMOKE_RUNE(ItemID.SMOKERUNE, new RuneType[]{RuneType.AIR, RuneType.FIRE}),
+	STEAM_RUNE(ItemID.STEAMRUNE, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+	LAVA_RUNE(ItemID.LAVARUNE, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
+	AETHER_RUNE(ItemID.AETHERRUNE, new RuneType[]{RuneType.SOUL, RuneType.COSMIC});
 
 	@Getter
 	private final int id;

--- a/src/main/java/com/autocasting/datatypes/RuneItem.java
+++ b/src/main/java/com/autocasting/datatypes/RuneItem.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-//import net.runelite.api.ItemID;
 import net.runelite.api.gameval.ItemID;
 
 import java.util.Map;


### PR DESCRIPTION
- Add Aether Rune, a new combination released with Yama which counts as a Soul + Cosmic rune
- Use the new ItemId path, as the existing one was deprecated last month.