### PR TITLE
Add twinflame staff datatype

### DIFF
--- a/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
+++ b/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
@@ -47,6 +47,8 @@ public enum InfiniteRuneItem
 	LAVA_BATTLESTAFF_OR(ItemID.LAVA_BATTLESTAFF_21198, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 	MYSTIC_LAVA_STAFF_OR(ItemID.MYSTIC_LAVA_STAFF_21200, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 
+	TWINFLAME_STAFF(ItemID.TWINFLAME_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+
 	KODAI_WAND(ItemID.KODAI_WAND, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
 	KODAI_WAND_23626(ItemID.KODAI_WAND_23626, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
 


### PR DESCRIPTION
To be fully transparent, I didn't even check if the project still builds like this, I just added the datatype. From what I gather without going too deep, this should fix the issue of not recognizing the infinite runes from twinflame staff.
Considering I don't know the runelite ItemID package, it might be spelled differently there, so maybe would be smart to double check.