### PR TITLE
Blacklisted items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.autocasting'
-version = '1.2'
+version = '1.3'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/autocasting/AutocastingClientData.java
+++ b/src/main/java/com/autocasting/AutocastingClientData.java
@@ -2,6 +2,8 @@ package com.autocasting;
 
 import com.autocasting.datatypes.Spell;
 import net.runelite.api.*;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.VarbitID;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -14,7 +16,7 @@ public class AutocastingClientData
 
 	public int getAutocastVarbit()
 	{
-		return client.getVarbitValue(AutocastingConstants.VARBIT_AUTOCAST_SPELL);
+		return client.getVarbitValue(VarbitID.AUTOCAST_SPELL);
 	}
 
 	public Spell getAutocastSpell()
@@ -25,7 +27,7 @@ public class AutocastingClientData
 
 	public int getWeaponTypeId()
 	{
-		return client.getVarbitValue(Varbits.EQUIPPED_WEAPON_TYPE);
+		return client.getVarbitValue(VarbitID.COMBAT_WEAPON_CATEGORY);
 	}
 
 	// Based off StatusBarsPlugin.java
@@ -38,7 +40,7 @@ public class AutocastingClientData
 		}
 		final Actor interacting = localPlayer.getInteracting();
 		boolean fightingNPC = interacting instanceof NPC && ArrayUtils.contains(((NPC) interacting).getComposition().getActions(), "Attack");
-		boolean fightingPlayer = interacting instanceof Player && client.getVarbitValue(Varbits.PVP_SPEC_ORB) == 1;
+		boolean fightingPlayer = interacting instanceof Player && client.getVarbitValue(VarbitID.PVP_AREA_CLIENT) == 1;
 		return fightingNPC || fightingPlayer;
 	}
 
@@ -64,11 +66,11 @@ public class AutocastingClientData
 
 	public ItemContainer getInventory()
 	{
-		return client.getItemContainer(InventoryID.INVENTORY);
+		return client.getItemContainer(InventoryID.INV);
 	}
 
 	public ItemContainer getEquipment()
 	{
-		return client.getItemContainer(InventoryID.EQUIPMENT);
+		return client.getItemContainer(InventoryID.WORN);
 	}
 }

--- a/src/main/java/com/autocasting/AutocastingConfig.java
+++ b/src/main/java/com/autocasting/AutocastingConfig.java
@@ -170,12 +170,25 @@ public interface AutocastingConfig extends Config
 		return AutocastingConstants.DEFAULT_CAST_RUNES_THRESHOLD;
 	}
 
+	@ConfigItem(
+		keyName = "hideUnlikelyItems",
+		name = "Hide Unlikely Weapons",
+		description = "Hide display on items which can autocast but aren't commonly used to cast.",
+		position = 13,
+		section = overlaySettings
+	)
+	default boolean hideUnlikelyItems()
+	{
+		return true;
+	}
+
+
 	// NOTIFICATIONS
 
 	@ConfigSection(
 		name = "Notifications",
 		description = "In-Game and Desktop Notification Settings",
-		position = 13
+		position = 14
 	)
 	String notificationSettings = "notifications";
 
@@ -183,7 +196,7 @@ public interface AutocastingConfig extends Config
 		keyName = "notifyOutOfCombat",
 		name = "Notify Out Of Combat",
 		description = "Controls if notifications for autocast spells will appear outside of combat.",
-		position = 14,
+		position = 15,
 		section = notificationSettings
 	)
 	default boolean notifyOutOfCombat()
@@ -195,7 +208,7 @@ public interface AutocastingConfig extends Config
 		keyName = "notifyOnStatDrain",
 		name = "Stat Drain Notification",
 		description = "Notifies you when your magic level falls below the level required for your autocast spell.",
-		position = 15,
+		position = 16,
 		section = notificationSettings
 	)
 	default AutocastingConstants.ChatNotificationType notifyOnStatDrain()
@@ -207,7 +220,7 @@ public interface AutocastingConfig extends Config
 		keyName = "notifyOnLowCasts",
 		name = "Low Casts Notification",
 		description = "Notifies you when your amount of casts falls to or below the Low Cast Threshold.",
-		position = 16,
+		position = 17,
 		section = notificationSettings
 	)
 	default AutocastingConstants.ChatNotificationType notifyOnLowCasts()
@@ -219,7 +232,7 @@ public interface AutocastingConfig extends Config
 		keyName = "notifyOnNoAutocastSelected",
 		name = "Alert on No Spell Selected",
 		description = "Enter alert mode when no autocast spell is selected.",
-		position = 17,
+		position = 18,
 		section = notificationSettings
 	)
 	default AutocastingConstants.ChatNotificationType notifyOnNoAutocastSelected()
@@ -233,7 +246,7 @@ public interface AutocastingConfig extends Config
 		keyName = "lowCastNotificationThreshold",
 		name = "Low Cast Threshold",
 		description = "Amount of casts to notify you on, based on your current runes.",
-		position = 18,
+		position = 19,
 		section = notificationSettings
 	)
 	default int lowCastNotificationThreshold()
@@ -246,7 +259,7 @@ public interface AutocastingConfig extends Config
 		keyName = "notifyOnLowCasts",
 		name = "No Casts Notification",
 		description = "Notifies you when you run out of runes to cast your autocast spell.",
-		position = 19,
+		position = 20,
 		section = notificationSettings
 	)
 	default AutocastingConstants.ChatNotificationType notifyOnNoCasts()

--- a/src/main/java/com/autocasting/AutocastingConstants.java
+++ b/src/main/java/com/autocasting/AutocastingConstants.java
@@ -1,8 +1,8 @@
 package com.autocasting;
 
 import lombok.AllArgsConstructor;
-import net.runelite.api.Varbits;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.gameval.ItemID;
 
 import java.awt.*;
 
@@ -29,6 +29,15 @@ public final class AutocastingConstants
 		VarbitID.RUNE_POUCH_QUANTITY_2,
 		VarbitID.RUNE_POUCH_QUANTITY_3,
 		VarbitID.RUNE_POUCH_QUANTITY_4,
+	};
+
+	public static final int[] BLACKLISTED_WEAPONS = {
+		ItemID.BLISTERWOOD_FLAIL,
+		ItemID.SOS_SKULL_SCEPTRE,
+		ItemID.SOS_SKULL_SCEPTRE_IMBUED,
+		ItemID.SARADOMIN_STAFF,
+		ItemID.GUTHIX_STAFF,
+		ItemID.ZAMORAK_STAFF
 	};
 
 	// Message constants

--- a/src/main/java/com/autocasting/AutocastingConstants.java
+++ b/src/main/java/com/autocasting/AutocastingConstants.java
@@ -2,6 +2,7 @@ package com.autocasting;
 
 import lombok.AllArgsConstructor;
 import net.runelite.api.Varbits;
+import net.runelite.api.gameval.VarbitID;
 
 import java.awt.*;
 
@@ -17,19 +18,17 @@ public final class AutocastingConstants
 	public static final Color RED_FLASH_COLOR = new Color(255, 0, 0, 186);
 
 	// Varbits
-	public static final int VARBIT_AUTOCAST_SPELL = 276;
-	public static final int VARBIT_FOUNTAIN_OF_RUNES = 4145;
 	public static final int[] VARBIT_RUNE_POUCH_RUNES = {
-		Varbits.RUNE_POUCH_RUNE1,
-		Varbits.RUNE_POUCH_RUNE2,
-		Varbits.RUNE_POUCH_RUNE3,
-		Varbits.RUNE_POUCH_RUNE4
+		VarbitID.RUNE_POUCH_TYPE_1,
+		VarbitID.RUNE_POUCH_TYPE_2,
+		VarbitID.RUNE_POUCH_TYPE_3,
+		VarbitID.RUNE_POUCH_TYPE_4,
 	};
 	public static final int[] VARBIT_RUNE_POUCH_AMOUNTS = {
-		Varbits.RUNE_POUCH_AMOUNT1,
-		Varbits.RUNE_POUCH_AMOUNT2,
-		Varbits.RUNE_POUCH_AMOUNT3,
-		Varbits.RUNE_POUCH_AMOUNT4
+		VarbitID.RUNE_POUCH_QUANTITY_1,
+		VarbitID.RUNE_POUCH_QUANTITY_2,
+		VarbitID.RUNE_POUCH_QUANTITY_3,
+		VarbitID.RUNE_POUCH_QUANTITY_4,
 	};
 
 	// Message constants

--- a/src/main/java/com/autocasting/AutocastingOverlay.java
+++ b/src/main/java/com/autocasting/AutocastingOverlay.java
@@ -48,6 +48,11 @@ class AutocastingOverlay extends OverlayPanel
 			return null;
 		}
 
+		if (config.hideUnlikelyItems() && state.isEquippedWeaponBlacklisted())
+		{
+			return null;
+		}
+
 		int casts = state.getCastsRemaining();
 		boolean displayCasts = config.showCastsRemaining()
 			&& casts <= config.displayCastLimit()

--- a/src/main/java/com/autocasting/AutocastingOverlay.java
+++ b/src/main/java/com/autocasting/AutocastingOverlay.java
@@ -110,7 +110,7 @@ class AutocastingOverlay extends OverlayPanel
 		}
 		panelComponent.getChildren().add(component);
 		panelComponent.setPreferredSize(new Dimension(
-			graphics.getFontMetrics().stringWidth(textPart) + 10,
+			graphics.getFontMetrics().stringWidth(textPart) + 30,
 			0
 		));
 

--- a/src/main/java/com/autocasting/AutocastingOverlay.java
+++ b/src/main/java/com/autocasting/AutocastingOverlay.java
@@ -108,14 +108,15 @@ class AutocastingOverlay extends OverlayPanel
 		{ // Exactly 1 is nonnull
 			component = (textComponent != null) ? textComponent : imageComponent;
 		}
+		panelComponent.getChildren().clear();
 		panelComponent.getChildren().add(component);
 		panelComponent.setPreferredSize(new Dimension(
-			graphics.getFontMetrics().stringWidth(textPart) + 30,
+			graphics.getFontMetrics().stringWidth(textPart) + 10,
 			0
 		));
 
 		configureBackground(casts);
-		return super.render(graphics);
+		return panelComponent.render(graphics);
 	}
 
 	private String getOverrideText(int casts)

--- a/src/main/java/com/autocasting/AutocastingRuneUtil.java
+++ b/src/main/java/com/autocasting/AutocastingRuneUtil.java
@@ -6,6 +6,7 @@ import net.runelite.api.EnumComposition;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.gameval.VarbitID;
 
 import javax.inject.Inject;
 import java.util.EnumMap;
@@ -157,7 +158,7 @@ public class AutocastingRuneUtil
 			return 0;
 		}
 
-		if (clientData.varbitValue(AutocastingConstants.VARBIT_FOUNTAIN_OF_RUNES) == 1)
+		if (clientData.varbitValue(VarbitID.FOUNTAIN_OF_RUNE_ACTIVE) == 1)
 		{
 			return Integer.MAX_VALUE;
 		}

--- a/src/main/java/com/autocasting/AutocastingState.java
+++ b/src/main/java/com/autocasting/AutocastingState.java
@@ -11,6 +11,9 @@ import lombok.Setter;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Map;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 
 @Singleton
 public class AutocastingState
@@ -31,6 +34,10 @@ public class AutocastingState
 	@Getter
 	@Setter
 	private boolean isEquippedWeaponMagic;
+
+	@Getter
+	@Setter
+	private boolean isEquippedWeaponBlacklisted;
 
 	@Getter
 	@Setter
@@ -162,6 +169,25 @@ public class AutocastingState
 		// The below types do have a casting option, but do not autocast spells, so leave them out.
 		// TYPE_6: These are salamanders. They do not autocast, but give magic xp, so technically have a "casting" option.
 		// TYPE_23: Trident, Sanguinesti, etc. Do not have autocast options, so do not show overlay when these are equipped.
+	}
+
+	public void updateIsBlacklisted()
+	{
+		ItemContainer equipment = clientData.getEquipment();
+		Item weaponSlot = equipment.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx());
+		if (weaponSlot == null) {
+			isEquippedWeaponBlacklisted = false;
+			return;
+		}
+
+		int weaponId = weaponSlot.getId();
+		for (int blacklistedId : AutocastingConstants.BLACKLISTED_WEAPONS) {
+			if (weaponId == blacklistedId) {
+				isEquippedWeaponBlacklisted = true;
+				return;
+			}
+		}
+		isEquippedWeaponBlacklisted = false;
 	}
 
 	public void updateMagicLevel(int boostedLevel)

--- a/src/main/java/com/autocasting/AutocastingSubscriptions.java
+++ b/src/main/java/com/autocasting/AutocastingSubscriptions.java
@@ -1,10 +1,10 @@
 package com.autocasting;
 
-import net.runelite.api.InventoryID;
 import net.runelite.api.Skill;
-import net.runelite.api.Varbits;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.events.*;
-import net.runelite.api.widgets.InterfaceID;
 import net.runelite.client.eventbus.Subscribe;
 
 import javax.inject.Inject;
@@ -23,23 +23,27 @@ public class AutocastingSubscriptions
 	{
 		switch (event.getVarbitId())
 		{
-			case AutocastingConstants.VARBIT_AUTOCAST_SPELL:
+			case VarbitID.AUTOCAST_SPELL:
 				state.setRecentlySentNoSpellSelectedNotification(false);
-			case Varbits.EQUIPPED_WEAPON_TYPE:
+			case VarbitID.COMBAT_WEAPON_CATEGORY:
 				state.updateIsEquippedWeaponMagic();
 				state.updateAutocastSpell();
 				break;
-			case Varbits.RUNE_POUCH_RUNE1:
-			case Varbits.RUNE_POUCH_RUNE2:
-			case Varbits.RUNE_POUCH_RUNE3:
-			case Varbits.RUNE_POUCH_RUNE4:
-			case Varbits.RUNE_POUCH_AMOUNT1:
-			case Varbits.RUNE_POUCH_AMOUNT2:
-			case Varbits.RUNE_POUCH_AMOUNT3:
-			case Varbits.RUNE_POUCH_AMOUNT4:
+			case VarbitID.RUNE_POUCH_TYPE_1:
+			case VarbitID.RUNE_POUCH_TYPE_2:
+			case VarbitID.RUNE_POUCH_TYPE_3:
+			case VarbitID.RUNE_POUCH_TYPE_4:
+			case VarbitID.RUNE_POUCH_TYPE_5:
+			case VarbitID.RUNE_POUCH_TYPE_6:
+			case VarbitID.RUNE_POUCH_QUANTITY_1:
+			case VarbitID.RUNE_POUCH_QUANTITY_2:
+			case VarbitID.RUNE_POUCH_QUANTITY_3:
+			case VarbitID.RUNE_POUCH_QUANTITY_4:
+			case VarbitID.RUNE_POUCH_QUANTITY_5:
+			case VarbitID.RUNE_POUCH_QUANTITY_6:
 				updateRunesPostClientTick = true;
 				break;
-			case AutocastingConstants.VARBIT_FOUNTAIN_OF_RUNES:
+			case VarbitID.FOUNTAIN_OF_RUNE_ACTIVE:
 				state.updateCastsRemaining(false);
 				break;
 		}
@@ -50,11 +54,11 @@ public class AutocastingSubscriptions
 	{
 		switch (event.getGroupId())
 		{
-			case InterfaceID.BANK:
-			case InterfaceID.BANK_INVENTORY:
-			case InterfaceID.DEPOSIT_BOX:
-			case InterfaceID.GROUP_STORAGE:
-			case InterfaceID.GROUP_STORAGE_INVENTORY:
+			case InterfaceID.BANKMAIN:
+			case InterfaceID.BANKSIDE:
+			case InterfaceID.BANK_DEPOSITBOX:
+			case InterfaceID.SHARED_BANK:
+			case InterfaceID.SHARED_BANK_SIDE:
 				state.setBanking(true);
 				state.setRecentlySentNoSpellSelectedNotification(false);
 		}
@@ -65,11 +69,11 @@ public class AutocastingSubscriptions
 	{
 		switch (event.getGroupId())
 		{
-			case InterfaceID.BANK:
-			case InterfaceID.BANK_INVENTORY:
-			case InterfaceID.DEPOSIT_BOX:
-			case InterfaceID.GROUP_STORAGE:
-			case InterfaceID.GROUP_STORAGE_INVENTORY:
+			case InterfaceID.BANKMAIN:
+			case InterfaceID.BANKSIDE:
+			case InterfaceID.BANK_DEPOSITBOX:
+			case InterfaceID.SHARED_BANK:
+			case InterfaceID.SHARED_BANK_SIDE:
 				state.setBanking(false);
 		}
 	}
@@ -88,12 +92,12 @@ public class AutocastingSubscriptions
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getContainerId() == InventoryID.EQUIPMENT.getId())
+		if (event.getContainerId() == InventoryID.WORN)
 		{
 			// Equipped items changed; should check to see if an infinite rune item is equipped
 			state.updateInfiniteRuneSources();
 		}
-		if (event.getContainerId() == InventoryID.INVENTORY.getId())
+		if (event.getContainerId() == InventoryID.INV)
 		{
 			// Inventory changed; should re-count runes
 			state.updateRunes();

--- a/src/main/java/com/autocasting/AutocastingSubscriptions.java
+++ b/src/main/java/com/autocasting/AutocastingSubscriptions.java
@@ -96,6 +96,7 @@ public class AutocastingSubscriptions
 		{
 			// Equipped items changed; should check to see if an infinite rune item is equipped
 			state.updateInfiniteRuneSources();
+			state.updateIsBlacklisted();
 		}
 		if (event.getContainerId() == InventoryID.INV)
 		{

--- a/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
+++ b/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
@@ -48,6 +48,8 @@ public enum InfiniteRuneItem
 	LAVA_BATTLESTAFF_OR(ItemID.LAVA_BATTLESTAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 	MYSTIC_LAVA_STAFF_OR(ItemID.MYSTIC_LAVA_STAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 
+	TWINFLAME_STAFF(ItemID.TWINFLAME_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+
 	KODAI_WAND(ItemID.KODAI_WAND, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
 	KODAI_WAND_23626(ItemID.BR_KODAI_WAND, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
 

--- a/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
+++ b/src/main/java/com/autocasting/datatypes/InfiniteRuneItem.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.EquipmentInventorySlot;
-import net.runelite.api.ItemID;
+import net.runelite.api.gameval.ItemID;
 
 import java.util.Map;
 
@@ -35,20 +35,21 @@ public enum InfiniteRuneItem
 	STEAM_BATTLESTAFF(ItemID.STEAM_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
 	LAVA_BATTLESTAFF(ItemID.LAVA_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 
-	MYSTIC_MIST_STAFF(ItemID.MYSTIC_MIST_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.WATER}),
-	MYSTIC_DUST_STAFF(ItemID.MYSTIC_DUST_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.EARTH}),
+	// 
+	MYSTIC_MIST_STAFF(ItemID.MYSTIC_MIST_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.WATER}),
+	MYSTIC_DUST_STAFF(ItemID.MYSTIC_DUST_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.EARTH}),
 	MYSTIC_MUD_STAFF(ItemID.MYSTIC_MUD_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.EARTH}),
-	MYSTIC_SMOKE_STAFF(ItemID.MYSTIC_SMOKE_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.FIRE}),
-	MYSTIC_STEAM_STAFF(ItemID.MYSTIC_STEAM_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+	MYSTIC_SMOKE_STAFF(ItemID.MYSTIC_SMOKE_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.AIR, RuneType.FIRE}),
+	MYSTIC_STEAM_STAFF(ItemID.MYSTIC_STEAM_BATTLESTAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
 	MYSTIC_LAVA_STAFF(ItemID.MYSTIC_LAVA_STAFF, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 
-	STEAM_BATTLESTAFF_OR(ItemID.STEAM_BATTLESTAFF_12795, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
-	MYSTIC_STEAM_STAFF_OR(ItemID.MYSTIC_STEAM_STAFF_12796, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
-	LAVA_BATTLESTAFF_OR(ItemID.LAVA_BATTLESTAFF_21198, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
-	MYSTIC_LAVA_STAFF_OR(ItemID.MYSTIC_LAVA_STAFF_21200, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
+	STEAM_BATTLESTAFF_OR(ItemID.STEAM_BATTLESTAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+	MYSTIC_STEAM_STAFF_OR(ItemID.MYSTIC_STEAM_BATTLESTAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER, RuneType.FIRE}),
+	LAVA_BATTLESTAFF_OR(ItemID.LAVA_BATTLESTAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
+	MYSTIC_LAVA_STAFF_OR(ItemID.MYSTIC_LAVA_STAFF_PRETTY, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.EARTH, RuneType.FIRE}),
 
 	KODAI_WAND(ItemID.KODAI_WAND, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
-	KODAI_WAND_23626(ItemID.KODAI_WAND_23626, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
+	KODAI_WAND_23626(ItemID.BR_KODAI_WAND, EquipmentInventorySlot.WEAPON, new RuneType[]{RuneType.WATER}),
 
 	TOME_OF_WATER(ItemID.TOME_OF_WATER, EquipmentInventorySlot.SHIELD, new RuneType[]{RuneType.WATER}),
 	TOME_OF_FIRE(ItemID.TOME_OF_FIRE, EquipmentInventorySlot.SHIELD, new RuneType[]{RuneType.FIRE}),

--- a/src/main/java/com/autocasting/datatypes/Pouch.java
+++ b/src/main/java/com/autocasting/datatypes/Pouch.java
@@ -3,7 +3,7 @@ package com.autocasting.datatypes;
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.ItemID;
+import net.runelite.api.gameval.ItemID;
 
 import java.util.Map;
 
@@ -12,12 +12,12 @@ import java.util.Map;
 public enum Pouch
 {
 
-	RUNE_POUCH(ItemID.RUNE_POUCH, PouchType.THREE_SLOTS),
-	RUNE_POUCH_L(ItemID.RUNE_POUCH_L, PouchType.THREE_SLOTS),
+	RUNE_POUCH(ItemID.BH_RUNE_POUCH, PouchType.THREE_SLOTS),
+	RUNE_POUCH_L(ItemID.BH_RUNE_POUCH_TROUVER, PouchType.THREE_SLOTS),
 	DIVINE_RUNE_POUCH(ItemID.DIVINE_RUNE_POUCH, PouchType.FOUR_SLOTS),
-	DIVINE_RUNE_POUCH_L(ItemID.DIVINE_RUNE_POUCH_L, PouchType.FOUR_SLOTS),
-	LMS_POUCH(ItemID.RUNE_POUCH_23650, PouchType.LMS),
-	EMIRS_ARENA_POUCH(ItemID.RUNE_POUCH_27086, PouchType.INFINITE);
+	DIVINE_RUNE_POUCH_L(ItemID.DIVINE_RUNE_POUCH_TROUVER, PouchType.FOUR_SLOTS),
+	LMS_POUCH(ItemID.BR_RUNE_REPLACEMENT, PouchType.LMS),
+	EMIRS_ARENA_POUCH(ItemID.PVPA_RUNE_REPLACEMENT, PouchType.INFINITE);
 
 	@Getter
 	private final int id;


### PR DESCRIPTION
- Toggle to remove overlay on items which can autocast but usually aren't: God Staves, Skull Sceptre, Blisterwood Flail
- Add Twinflame Staff
- Update deprecated ids to new gameval imports recommended by Runelite devs
- Fix an issue with the overlay not resizing properly. It will now stretch or shrink to match the length of the text.